### PR TITLE
Restore WSS build utilities

### DIFF
--- a/WSS_MIGRATION.md
+++ b/WSS_MIGRATION.md
@@ -232,6 +232,13 @@ The Windows release build and smoke test must cover:
   flags.
 - Confirmed the legacy-term audit is empty outside this tracker, historical
   screenshot URLs, and the documented MSIX compatibility identity.
+- The first Windows packaging run reached the main WSS compile after
+  successfully building ComManager, RustInterop, DISMService, and
+  QuantumRelayWSS. It exposed two generic CommonCore utilities that the initial
+  caller audit had incorrectly classified as unused. Restored only their
+  WSS-required functionality (`FileUtility` and `CertificateGenerator`),
+  removed the ACS-only certificate workflow, and removed three duplicate using
+  directives promoted to errors by the Release build.
 
 ## Completion Definition
 

--- a/Windows Security Studio/CommonCore/CommonCore.projitems
+++ b/Windows Security Studio/CommonCore/CommonCore.projitems
@@ -60,6 +60,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Others\AllCertificatesGrabber.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Others\AllFileSigners.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Others\ClipboardManagement.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Others\CertificateCreator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Others\GetFilesFast.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LLPackageReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Signing\Helper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Signing\Main.cs" />

--- a/Windows Security Studio/CommonCore/Others/CertificateCreator.cs
+++ b/Windows Security Studio/CommonCore/Others/CertificateCreator.cs
@@ -1,0 +1,239 @@
+// MIT License
+//
+// Copyright (c) 2023-Present - Violet Hansen - (aka HotCakeX on GitHub) - Email Address: spynetgirl@outlook.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// See here for more information: https://github.com/OFFSECHQ/windows-security-studio/blob/main/LICENSE
+//
+
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+namespace CommonCore.Others;
+
+internal static class CertificateGenerator
+{
+	// Enum representing the applicable certificate stores
+	internal enum CertificateStoreLocation
+	{
+		User,
+		Machine
+	}
+
+	internal static X509Certificate2 GenerateSelfSignedCertificate(
+		string subjectName,
+		int validityInYears,
+		int keySize,
+		HashAlgorithmName hashAlgorithm,
+		CertificateStoreLocation? storeLocation,
+		bool UserProtectedPrivateKey,
+		bool ExportablePrivateKey,
+		string? cerExportFilePath = null,
+		string? friendlyName = null,
+		string? pfxExportFilePath = null,
+		string? pfxPassword = null)
+	{
+		// Check if the subject name already starts with "CN="
+		// If it does, use it as-is; otherwise, prepend "CN="
+		X500DistinguishedName distinguishedName = subjectName.StartsWith("CN=", StringComparison.OrdinalIgnoreCase)
+			? new(subjectName)
+			: new($"CN={subjectName}");
+
+		using RSA rsa = RSA.Create(keySize);
+
+		CertificateRequest request = new(distinguishedName, rsa, hashAlgorithm, RSASignaturePadding.Pkcs1);
+
+		// adds basic constraints to the certificate request to make it a non-CA and end entity certificate.
+		request.CertificateExtensions.Add(
+			new X509BasicConstraintsExtension(false, false, 0, true));
+
+		// Add key usage
+		request.CertificateExtensions.Add(
+			new X509KeyUsageExtension(
+				X509KeyUsageFlags.DigitalSignature,
+				true));
+
+
+		// Add subject key identifier
+		// Its raw data which is a byte array will always start with 4, 20
+		// 4: This indicates the ASN.1 type is an OCTET STRING.
+		// 20: The length of the OCTET STRING is 20 bytes.
+		// Remaining bytes are generated randomly for each certificate
+
+		// adds "[1]Application Certificate Policy:Policy Identifier=Code Signing" as the value for Application Policies extension. The certificate made in CA role in Windows Server (using Code Signing template) also adds this extension.
+		request.CertificateExtensions.Add(
+			new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+
+		// Add enhanced key usage
+		// Code Signing
+		request.CertificateExtensions.Add(
+			new X509EnhancedKeyUsageExtension(
+				[new Oid(Signing.Structure.CodeSigningOID)],
+				false)
+			);
+
+		// Add custom extension for "Application Policies"
+		// https://learn.microsoft.com/openspecs/windows_protocols/ms-crtd/44012f2d-5ef3-440d-a61b-b30d3d978130
+		// https://learn.microsoft.com/previous-versions/windows/it-pro/windows-server-2003/cc776986(v=ws.10)?redirectedfrom=MSDN
+		// https://learn.microsoft.com/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc754305(v=ws.10)
+		// Application Policies OID
+		Oid appPoliciesOid = new("1.3.6.1.4.1.311.21.10");
+		// this must be set as specified and not randomly generated
+		byte[] appPoliciesValue = [48, 12, 48, 10, 6, 8, 43, 6, 1, 5, 5, 7, 3, 3];
+		X509Extension appPoliciesExtension = new(appPoliciesOid, appPoliciesValue, false);
+		request.CertificateExtensions.Add(appPoliciesExtension);
+
+
+		DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+		DateTimeOffset notAfter = notBefore.AddYears(validityInYears);
+
+		// Generate the certificate
+		using X509Certificate2 cert = request.CreateSelfSigned(notBefore, notAfter);
+
+
+		// Export the certificate for .PFX file as Byte Array
+		byte[] certData = cert.Export(X509ContentType.Pfx, pfxPassword);
+
+		// https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.x509certificateloader.loadpkcs12
+		// https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.x509keystorageflags
+
+		X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.PersistKeySet;
+
+		if (UserProtectedPrivateKey)
+		{
+			keyStorageFlags |= X509KeyStorageFlags.UserProtected;
+		}
+
+		if (ExportablePrivateKey)
+		{
+			keyStorageFlags |= X509KeyStorageFlags.Exportable;
+		}
+
+		X509Certificate2 generatedCert = X509CertificateLoader.LoadPkcs12(certData, pfxPassword, keyStorageFlags);
+
+		// Set the friendly name if provided
+		if (!string.IsNullOrEmpty(friendlyName))
+		{
+			generatedCert.FriendlyName = friendlyName;
+		}
+
+		// If path to export .cer file is provided, export the certificate (public key only)
+		if (!string.IsNullOrEmpty(cerExportFilePath))
+		{
+			// Export as DER-encoded X.509 .cer file
+			byte[] cerData = cert.Export(X509ContentType.Cert);
+			File.WriteAllBytes(cerExportFilePath, cerData);
+		}
+
+		// If path to export .pfx file is provided, export the certificate (public + private keys)
+		if (!string.IsNullOrEmpty(pfxExportFilePath))
+		{
+			File.WriteAllBytes(pfxExportFilePath, certData);
+		}
+
+		if (storeLocation is not null)
+		{
+			// Store the certificate in the specified certificate store
+			StoreCertificateInStore(generatedCert, storeLocation, false);
+		}
+
+		return generatedCert;
+	}
+
+
+	/// <summary>
+	/// Stores a certificate in a specified certificate store location, optionally including only the public key.
+	/// </summary>
+	/// <param name="cert">The certificate to be stored in the designated certificate store.</param>
+	/// <param name="storeLocation">Indicates whether the certificate should be stored for the current user or the local machine.</param>
+	/// <param name="publicKeyOnly">Determines if only the public key of the certificate should be stored.</param>
+	internal static void StoreCertificateInStore(X509Certificate2 cert, CertificateStoreLocation? storeLocation, bool publicKeyOnly)
+	{
+		// Choose the store based on the user selection
+		StoreName storeName = storeLocation == CertificateStoreLocation.User ? StoreName.My : StoreName.Root;
+		StoreLocation location = storeLocation == CertificateStoreLocation.User ? StoreLocation.CurrentUser : StoreLocation.LocalMachine;
+
+
+		if (publicKeyOnly)
+		{
+			// Export the certificate as a public key only (DER-encoded)
+			byte[] publicKeyData = cert.Export(X509ContentType.Cert);
+
+			// Reload the certificate from the exported public key data and replace the incoming data to eliminate the private key
+			// https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.x509certificateloader.loadcertificate
+			cert = X509CertificateLoader.LoadCertificate(publicKeyData);
+		}
+
+		using X509Store store = new(storeName, location);
+		store.Open(OpenFlags.ReadWrite);
+		store.Add(cert);
+		store.Close();
+	}
+
+
+	/// <summary>
+	/// Searches through all the relevant certificate stores for any certificate with a given Subject Common Name
+	/// And deletes all of the detected instances
+	/// </summary>
+	/// <param name="subjectName"></param>
+	internal static void DeleteCertificateByCN(string subjectName)
+	{
+		// Search through both user and machine certificate stores
+		DeleteCertificateFromAllStores(subjectName, StoreLocation.CurrentUser);
+		DeleteCertificateFromAllStores(subjectName, StoreLocation.LocalMachine);
+	}
+
+	// List of all known certificate store names
+	private static readonly string[] AllStoreNames =
+	[
+			"My", // Personal / Certificates
+            "Root", // Trusted Root Certification Authorities / Certificates
+            "CA", // Intermediate Certification Authorities / Certificates
+            "AuthRoot", // Third-Party Root Certification Authorities / Certificates
+            "TrustedPeople", // Trusted People
+            "TrustedPublisher" // Trusted Publishers
+	];
+
+	/// <summary>
+	/// Deletes the certificate
+	/// </summary>
+	/// <param name="subjectName"></param>
+	/// <param name="storeLocation"></param>
+	private static void DeleteCertificateFromAllStores(string subjectName, StoreLocation storeLocation)
+	{
+		// Iterate through all specified store names
+		foreach (string storeName in AllStoreNames)
+		{
+			using X509Store store = new(storeName, storeLocation);
+			// MaxAllowed is necessary otherwise we'd get access denied error
+			store.Open(OpenFlags.MaxAllowed | OpenFlags.IncludeArchived | OpenFlags.OpenExistingOnly);
+
+			// Loop through the certificates in the store and find the one with the matching CN
+			foreach (X509Certificate2 cert in store.Certificates)
+			{
+				if (cert.SubjectName.Name.Contains($"CN={subjectName}", StringComparison.OrdinalIgnoreCase))
+				{
+					// Certificate found with the matching CN, so delete it
+					store.Remove(cert);
+					Logger.Write(string.Format(
+						GlobalVars.GetStr("DeletedCertificateFromStoreMessage"),
+						subjectName,
+						storeName));
+				}
+			}
+
+			store.Close();
+		}
+	}
+
+}

--- a/Windows Security Studio/CommonCore/Others/GetFilesFast.cs
+++ b/Windows Security Studio/CommonCore/Others/GetFilesFast.cs
@@ -1,0 +1,355 @@
+// MIT License
+//
+// Copyright (c) 2023-Present - Violet Hansen - (aka HotCakeX on GitHub) - Email Address: spynetgirl@outlook.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// See here for more information: https://github.com/OFFSECHQ/windows-security-studio/blob/main/LICENSE
+//
+
+using System.Collections.Concurrent;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Enumeration;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CommonCore.Others;
+
+internal static class FileUtility
+{
+
+	/// <summary>
+	/// Method that takes 2 collections, one containing file paths and the other containing folder paths.
+	/// It checks them and returns the unique file paths that are not in any of the folder paths.
+	/// Performs this check recursively, so it works if a file path is in a sub-directory of a folder path.
+	/// It works even if the file paths or folder paths are non-existent/deleted, but they still need to be valid file/folder paths.
+	/// </summary>
+	private static HashSet<string> TestFilePath(
+		IReadOnlyCollection<string> directoryPaths,
+		IReadOnlyCollection<string> filePaths)
+	{
+		// Normalize each directory‐path into an absolute path ending with a single separator.
+		HashSet<string> normalizedDirs = new(StringComparer.OrdinalIgnoreCase);
+
+		foreach (string dir in directoryPaths)
+		{
+			if (string.IsNullOrWhiteSpace(dir))
+				continue;
+
+			// Get full absolute path, trim any trailing separator, then add exactly one.
+			string fullDir = Path.GetFullPath(dir)
+								 .TrimEnd(Path.DirectorySeparatorChar)
+								 + Path.DirectorySeparatorChar;
+
+			_ = normalizedDirs.Add(fullDir);
+		}
+
+		// Walk through each file. Normalize its full path, then climb its parent chain.
+		// If we ever match one of the normalizedDirs, skip it. Otherwise, add the original file string.
+		HashSet<string> output = new(StringComparer.OrdinalIgnoreCase);
+
+		foreach (string file in filePaths)
+		{
+			if (string.IsNullOrWhiteSpace(file))
+				continue;
+
+			// Normalize file into an absolute path
+			string fullFilePath;
+			try
+			{
+				fullFilePath = Path.GetFullPath(file);
+			}
+			catch (Exception)
+			{
+				// If the file‐string is not a valid path, skip it
+				continue;
+			}
+
+			// Start checking from the file's parent directory upwards
+			string? currentDir = Path.GetDirectoryName(fullFilePath);
+			bool residesUnderExcluded = false;
+
+			while (currentDir is not null)
+			{
+				// Normalize this ancestor folder (absolute, trailing separator)
+				string normalizedAncestor = Path.GetFullPath(currentDir)
+											 .TrimEnd(Path.DirectorySeparatorChar)
+											 + Path.DirectorySeparatorChar;
+
+				if (normalizedDirs.Contains(normalizedAncestor))
+				{
+					residesUnderExcluded = true;
+					break;
+				}
+
+				currentDir = Path.GetDirectoryName(currentDir);
+			}
+
+			if (!residesUnderExcluded)
+			{
+				// Use the original file‐string (not the full‐path) in the output set
+				_ = output.Add(file);
+			}
+		}
+
+		// Return the set of files that do NOT reside under any of the provided directories.
+		return output;
+	}
+
+	// Used to enumerate all files, recursively inside each sub-directory of each user-selected directory
+	private static readonly EnumerationOptions RecursiveEnumeration = new()
+	{
+		IgnoreInaccessible = true,
+		RecurseSubdirectories = true,
+		AttributesToSkip = FileAttributes.None,
+		MatchCasing = MatchCasing.CaseInsensitive,
+		ReturnSpecialDirectories = false,
+		MaxRecursionDepth = int.MaxValue,
+		BufferSize = 65536
+	};
+
+	// Used to only enumerate the files in each user-selected directories
+	private static readonly EnumerationOptions NonRecurseEnumeration = new()
+	{
+		IgnoreInaccessible = true,
+		RecurseSubdirectories = false,
+		AttributesToSkip = FileAttributes.None,
+		MatchCasing = MatchCasing.CaseInsensitive,
+		ReturnSpecialDirectories = false,
+		MaxRecursionDepth = int.MaxValue,
+		BufferSize = 65536
+	};
+
+
+	// Default executable and script extensions, case-insensitive.
+	private static readonly FrozenSet<string> DefaultExecutableExtensions = new string[]
+	{
+		".sys", ".exe", ".com", ".dll", ".rll", ".ocx", ".msp", ".mst", ".msi",
+		".js", ".vbs", ".ps1", ".appx", ".bin", ".bat", ".hxs", ".mui", ".lex", ".mof"
+	}.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+
+	/// <summary>
+	/// A flexible and fast method that accepts directory and file paths and
+	/// returns files matching a configurable extension set.
+	/// </summary>
+	/// <param name="directories">Directories to process.</param>
+	/// <param name="files">Files to process.</param>
+	/// <param name="extensionsToFilterBy">Extensions to filter by. If null or empty, the default executable and script extensions are used.</param>
+	/// <returns>A Tuple containing the IEnumerable and count of the data</returns>
+	internal static (IEnumerable<string>, int) GetFilesFast(
+		IReadOnlyCollection<string>? directories,
+		IReadOnlyCollection<string>? files,
+		string[]? extensionsToFilterBy,
+		CancellationToken? cToken = null)
+	{
+		// Create a Stopwatch instance and start measuring time
+		Stopwatch stopwatch = Stopwatch.StartNew();
+
+		// A FrozenSet used to store extensions to filter files
+		FrozenSet<string> extensions = extensionsToFilterBy is { Length: > 0 }
+			? extensionsToFilterBy.ToFrozenSet(StringComparer.OrdinalIgnoreCase)
+			: DefaultExecutableExtensions;
+
+		// If custom extensions are provided, use them and make them case-insensitive
+
+		// https://learn.microsoft.com/dotnet/api/system.collections.concurrent.blockingcollection-1
+		// https://learn.microsoft.com/dotnet/standard/collections/thread-safe/when-to-use-a-thread-safe-collection
+		// https://learn.microsoft.com/dotnet/standard/collections/thread-safe/blockingcollection-overview
+		// We could use "Using" statement here but then we wouldn't be able to pass the collection's enumerable as the return object and instead would have to materialize it into an Array/List which would degrade performance.
+		BlockingCollection<string> bc = [];
+
+		// To store all of the tasks
+		List<Task> tasks = [];
+
+
+		#region Directories
+
+		// Process directories if provided
+		if (directories is { Count: > 0 })
+		{
+			foreach (string directory in directories)
+			{
+				// Process files in the current directory - non-recursive
+				tasks.Add(Task.Run(() =>
+				{
+
+					FileSystemEnumerable<FileSystemInfo> enumeration = new(
+							directory,
+							(ref entry) => entry.ToFileSystemInfo(),
+							NonRecurseEnumeration)
+					{
+						ShouldIncludePredicate = (ref entry) =>
+						{
+							// Skip directories.
+							if (entry.IsDirectory)
+							{
+								return false;
+							}
+
+							// If the file has the correct extension or wildcard was used
+							if (extensions.Contains("*") || extensions.Contains(Path.GetExtension(entry.ToFullPath())))
+							{
+								return true;
+							}
+
+							return false;
+						}
+					};
+
+					IEnumerator<FileSystemInfo> enumerator = enumeration.GetEnumerator();
+
+					while (true)
+					{
+						cToken?.ThrowIfCancellationRequested();
+
+						try
+						{
+							// Move to the next file
+							// The reason we use MoveNext() instead of foreach loop is that protected/inaccessible files
+							// Would throw errors and this way we can catch them and move to the next file without terminating the entire loop
+							if (!enumerator.MoveNext())
+							{
+								// If we reach the end of the enumeration, we break out of the loop
+								break;
+							}
+							bc.Add(enumerator.Current.FullName);
+						}
+						catch { }
+					}
+				}));
+
+
+				// Check for immediate sub-directories and process them if present
+				DirectoryInfo[] subDirectories = new DirectoryInfo(directory).GetDirectories();
+
+				if (subDirectories.Length > 0)
+				{
+					foreach (DirectoryInfo subDirectory in subDirectories)
+					{
+						// Process files in each sub-directory concurrently
+						tasks.Add(Task.Run(() =>
+						{
+
+							FileSystemEnumerable<FileSystemInfo> enumeration = new(
+								subDirectory.FullName,
+								(ref entry) => entry.ToFileSystemInfo(),
+								RecursiveEnumeration)
+							{
+								ShouldIncludePredicate = (ref entry) =>
+								{
+									// Skip directories.
+									if (entry.IsDirectory)
+									{
+										return false;
+									}
+
+									// If the file has the correct extension or wildcard was used
+									if (extensions.Contains("*") || extensions.Contains(Path.GetExtension(entry.ToFullPath())))
+									{
+										return true;
+									}
+
+									return false;
+								}
+							};
+
+							IEnumerator<FileSystemInfo> subEnumerator = enumeration.GetEnumerator();
+							while (true)
+							{
+								cToken?.ThrowIfCancellationRequested();
+
+								try
+								{
+									if (!subEnumerator.MoveNext())
+									{
+										break;
+									}
+									bc.Add(subEnumerator.Current.FullName);
+								}
+								catch { }
+							}
+						}));
+					}
+				}
+
+			}
+		}
+
+		#endregion
+
+
+		#region Files
+
+		// If files are provided, process them
+		if (files is { Count: > 0 })
+		{
+
+			// Ensure the files aren't already in the directories that were scanned
+			IReadOnlyCollection<string> filesToUse = directories is not null && directories.Count > 0 ?
+				TestFilePath(directories, files) :
+				files;
+
+			// If user provided wildcard then add all files without checking their extensions
+			if (extensions.Contains("*"))
+			{
+				foreach (string file in filesToUse)
+				{
+					cToken?.ThrowIfCancellationRequested();
+
+					bc.Add(file);
+				}
+			}
+			// If user provided no extensions to filter by or provided extensions that are not wildcard
+			else
+			{
+				foreach (string file in filesToUse)
+				{
+					cToken?.ThrowIfCancellationRequested();
+
+					if (extensions.Contains(Path.GetExtension(file)))
+					{
+						bc.Add(file);
+					}
+				}
+			}
+		}
+
+		#endregion
+
+
+		// Wait for all tasks to be completed
+		Task.WaitAll(tasks);
+
+		// Stop adding items to the collection
+		bc.CompleteAdding();
+
+		// Stop measuring time
+		stopwatch.Stop();
+
+		// Get the elapsed time
+		TimeSpan elapsedTime = stopwatch.Elapsed;
+
+		Logger.Write(
+			string.Format(
+				GlobalVars.GetStr("FileEnumerationDurationMessage"),
+				elapsedTime.Hours,
+				elapsedTime.Minutes,
+				elapsedTime.Seconds
+			)
+		);
+
+		return (bc.GetConsumingEnumerable(), bc.Count);
+	}
+}

--- a/Windows Security Studio/Protect/MUnit.cs
+++ b/Windows Security Studio/Protect/MUnit.cs
@@ -28,7 +28,6 @@ using WindowsSecurityStudio.CustomUIElements;
 using WindowsSecurityStudio.ViewModels;
 using WindowsSecurityStudio.GroupPolicy;
 using WindowsSecurityStudio.Helpers;
-using WindowsSecurityStudio.ViewModels;
 using Microsoft.UI.Xaml;
 
 namespace WindowsSecurityStudio.Protect;

--- a/Windows Security Studio/ViewModels/UpdateVM.cs
+++ b/Windows Security Studio/ViewModels/UpdateVM.cs
@@ -32,7 +32,6 @@ using Windows.Foundation;
 using Windows.Management.Deployment;
 using Windows.System;
 
-using WindowsSecurityStudio.Others;
 using WindowsSecurityStudio.ViewModels;
 namespace WindowsSecurityStudio.ViewModels;
 

--- a/Windows Security Studio/WindowComponents/NavigationService.cs
+++ b/Windows Security Studio/WindowComponents/NavigationService.cs
@@ -27,7 +27,6 @@ using Windows.Graphics;
 using WinRT;
 
 using WindowsSecurityStudio.WindowComponents;
-using WindowsSecurityStudio.ViewModels;
 using System.Collections.Frozen;
 using System.Runtime.InteropServices;
 namespace WindowsSecurityStudio.WindowComponents;


### PR DESCRIPTION
Restores the two generic CommonCore utilities required by WSS, removes their ACS-only logic, and fixes duplicate using directives reported by the Windows Release build.