### PR TITLE
Fix WSS release analyzer errors

### DIFF
--- a/WSS_MIGRATION.md
+++ b/WSS_MIGRATION.md
@@ -239,6 +239,11 @@ The Windows release build and smoke test must cover:
   WSS-required functionality (`FileUtility` and `CertificateGenerator`),
   removed the ACS-only certificate workflow, and removed three duplicate using
   directives promoted to errors by the Release build.
+- The second Windows packaging run again built every native and helper
+  component, then exposed four style diagnostics promoted to errors in the main
+  Release build. Corrected the query formatting, simplified two animation null
+  checks, and removed an unnecessary nullable suppression before rerunning the
+  complete Windows release pipeline.
 
 ## Completion Definition
 

--- a/Windows Security Studio/CustomUIElements/HomePageCarousel/AnimatedImage.xaml.cs
+++ b/Windows Security Studio/CustomUIElements/HomePageCarousel/AnimatedImage.xaml.cs
@@ -71,11 +71,8 @@ internal sealed partial class AnimatedImage : UserControl
 
 	private void AnimatedImage_Unloaded(object sender, RoutedEventArgs e)
 	{
-		if (selectAnimation != null)
-		{
-			selectAnimation.Completed -= SelectAnimation_Completed;
-			selectAnimation = null;
-		}
+		selectAnimation?.Completed -= SelectAnimation_Completed;
+		selectAnimation = null;
 	}
 
 	private void IsImageChanged(Uri oldValue, Uri newValue)
@@ -83,10 +80,7 @@ internal sealed partial class AnimatedImage : UserControl
 		BottomImage.Source = new BitmapImage(this.ImageUrl);
 		BottomImage.Opacity = 1;
 
-		if (selectAnimation != null)
-		{
-			selectAnimation.Completed -= SelectAnimation_Completed;
-		}
+		selectAnimation?.Completed -= SelectAnimation_Completed;
 
 		selectAnimation = [new OpacityAnimation() { From = 1, To = 0, Duration = TimeSpan.FromMilliseconds(800) }];
 		selectAnimation.Completed += SelectAnimation_Completed;

--- a/Windows Security Studio/Helpers/IMUnitListViewModel.cs
+++ b/Windows Security Studio/Helpers/IMUnitListViewModel.cs
@@ -151,8 +151,8 @@ internal interface IMUnitListViewModel : INotifyPropertyChanged
 
 				// Grab Protection Categories objects
 				query = from item in viewModel.AllMUnits
-							// Group the items returned from the query, sort and select the ones you want to keep
-						group item by item.Name![..1].ToUpperInvariant() into g
+						// Group the items returned from the query, sort and select the ones you want to keep
+						group item by item.Name[..1].ToUpperInvariant() into g
 						orderby g.Key
 						// GroupInfoListForMUnit is a simple custom class that has an IEnumerable type attribute, and
 						// a key attribute. The IGrouping-typed variable g now holds the App objects,

--- a/Windows Security Studio/ViewModels/IntuneVM.cs
+++ b/Windows Security Studio/ViewModels/IntuneVM.cs
@@ -380,7 +380,7 @@ internal sealed partial class IntuneVM : ViewModelBase, IGraphAuthHost, IDisposa
 
 			await Main.DeleteConfigurationPolicy(
 				AuthCompanionCLS.CurrentActiveAccount,
-				SelectedPolicyInListView.Id!);
+				SelectedPolicyInListView.Id);
 
 			MainInfoBar.WriteSuccess("Policy deleted successfully.");
 


### PR DESCRIPTION
## Summary
- fix the four analyzer errors exposed by the second Windows release run
- retain the second run result in the migration tracker

## Validation
- targeted `dotnet format` analyzer check reports no IDE0055, IDE0031, or IDE0370 diagnostics
- `git diff --check` passes
- all native/helper builds completed successfully in run 30144211670 before the main analyzer failure