### PR TITLE
Restore required WSS query nullability assertion

### DIFF
--- a/WSS_MIGRATION.md
+++ b/WSS_MIGRATION.md
@@ -244,6 +244,10 @@ The Windows release build and smoke test must cover:
   Release build. Corrected the query formatting, simplified two animation null
   checks, and removed an unnecessary nullable suppression before rerunning the
   complete Windows release pipeline.
+- The third Windows packaging run confirmed those four original diagnostics
+  were resolved. A broader local formatter had suggested removing a separate
+  query nullability suppression that the actual Windows compiler still
+  requires; restored it after the runner reported `CS8602`.
 
 ## Completion Definition
 

--- a/Windows Security Studio/Helpers/IMUnitListViewModel.cs
+++ b/Windows Security Studio/Helpers/IMUnitListViewModel.cs
@@ -152,7 +152,7 @@ internal interface IMUnitListViewModel : INotifyPropertyChanged
 				// Grab Protection Categories objects
 				query = from item in viewModel.AllMUnits
 						// Group the items returned from the query, sort and select the ones you want to keep
-						group item by item.Name[..1].ToUpperInvariant() into g
+						group item by item.Name![..1].ToUpperInvariant() into g
 						orderby g.Key
 						// GroupInfoListForMUnit is a simple custom class that has an IEnumerable type attribute, and
 						// a key attribute. The IGrouping-typed variable g now holds the App objects,


### PR DESCRIPTION
## Summary
- restore the nullability assertion required by the Windows compiler
- retain the query indentation fix for IDE0055
- record the third Windows validation result

## Evidence
Run 30144562780 confirmed the original four style diagnostics are resolved and reported only CS8602 at this expression after the assertion was removed.