### PR TITLE
Handle private WSS release attestations

### DIFF
--- a/.github/workflows/Build Windows Security Studio MSIX Package.yml
+++ b/.github/workflows/Build Windows Security Studio MSIX Package.yml
@@ -676,8 +676,17 @@ jobs:
                       Invoke-WebRequest -Uri 'https://github.com/microsoft/sbom-tool/releases/latest/download/sbom-tool-win-x64.exe' -OutFile "${Env:RUNNER_TEMP}\sbom-tool.exe"
                   }
 
+                  # Use a no-space junction for source discovery. The SBOM
+                  # tool otherwise passes Cargo manifest paths containing
+                  # "Windows Security Studio" without preserving the quotes.
+                  [string]$SbomSourcePath = [System.IO.Path]::Combine($env:RUNNER_TEMP, 'wss-source')
+                  if (Test-Path -LiteralPath $SbomSourcePath) {
+                      Remove-Item -LiteralPath $SbomSourcePath -Force
+                  }
+                  $null = New-Item -ItemType Junction -Path $SbomSourcePath -Target $script:WSSDirectory
+
                   # https://github.com/microsoft/sbom-tool/blob/main/docs/sbom-tool-arguments.md
-                  . "${Env:RUNNER_TEMP}\sbom-tool.exe" generate -b $MSIXBundleOutput -bc .\ -pn 'Windows Security Studio' -ps 'OFFSECHQ' -pv $MSIXVersion -nsb 'https://github.com/OFFSECHQ/windows-security-studio' -V Verbose -gt true -li true -pm true -D true -lto 80
+                  . "${Env:RUNNER_TEMP}\sbom-tool.exe" generate -b $MSIXBundleOutput -bc $SbomSourcePath -pn 'Windows Security Studio' -ps 'OFFSECHQ' -pv $MSIXVersion -nsb 'https://github.com/OFFSECHQ/windows-security-studio' -V Verbose -gt true -li true -pm true -D true -lto 80
 
                   # Saving the details of the SBOM file
                   Add-Content -Path ($env:GITHUB_ENV, $env:GITHUB_OUTPUT) -Value "SBOM_PATH=$MSIXBundleOutput/_manifest/spdx_2.2/manifest.spdx.json"
@@ -833,6 +842,7 @@ jobs:
   # The Attestation runs right after build and no other job, especially 3rd party actions/steps etc. should run in between.
   attest:
     needs: [build]
+    if: ${{ github.event.repository.visibility == 'public' }}
     runs-on: windows-2025
     permissions:
       attestations: write
@@ -849,12 +859,13 @@ jobs:
         run: ls -R Downloaded-Artifacts
 
       - name: Generating Artifact Attestation
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-path: "Downloaded-Artifacts/*" # Use all the files in the artifact downloads folder
 
   SbomAttest:
     needs: [build]
+    if: ${{ github.event.repository.visibility == 'public' }}
     runs-on: windows-2025
     permissions:
       contents: read
@@ -872,14 +883,14 @@ jobs:
         run: ls -R Downloaded-Artifacts
 
       - name: Generating SBOM attestation
-        uses: actions/attest-sbom@v4
+        uses: actions/attest@v4
         with:
           subject-path: "Downloaded-Artifacts/*" # Use all the files in the artifact downloads folder
           sbom-path: ./Downloaded-Artifacts/manifest.spdx.json
           show-summary: true
 
   final:
-    needs: [build, attest, SbomAttest]
+    needs: [build]
     runs-on: windows-2025
     permissions:
       contents: write

--- a/WSS_MIGRATION.md
+++ b/WSS_MIGRATION.md
@@ -248,6 +248,15 @@ The Windows release build and smoke test must cover:
   were resolved. A broader local formatter had suggested removing a separate
   query nullability suppression that the actual Windows compiler still
   requires; restored it after the runner reported `CS8602`.
+- The fourth Windows run completed the full 15-minute build job: every native
+  and managed component compiled, the signed MSIX bundle and install kit were
+  created, the SBOM and symbols were generated, and all six draft-release
+  assets uploaded. GitHub then rejected both provenance jobs because artifact
+  attestations are unavailable to user-owned private repositories. Made those
+  jobs conditional on public visibility, migrated the deprecated SBOM action to
+  `actions/attest`, and allowed the release metadata job to complete
+  independently. Added a no-space source junction for SBOM Cargo discovery to
+  work around the tool's unquoted manifest-path handling.
 
 ## Completion Definition
 


### PR DESCRIPTION
## Summary
- run GitHub artifact attestations only when repository visibility supports them
- migrate the deprecated SBOM attestation wrapper to `actions/attest@v4`
- allow the release metadata job to follow the successful build directly
- use a no-space source junction so SBOM Cargo discovery can parse WSS manifests
- record the successful 15m19s release build and the private-repository limitation

## Validation
- `actionlint` 1.7.12 passes
- embedded PowerShell parses without errors
- `git diff --check` passes
- run 30144761692 completed the build job and uploaded all six draft-release assets