### PR TITLE
Normalize WSS release asset replacement

### DIFF
--- a/.github/workflows/Build Windows Security Studio MSIX Package.yml
+++ b/.github/workflows/Build Windows Security Studio MSIX Package.yml
@@ -607,16 +607,24 @@ jobs:
                   # tool otherwise passes Cargo manifest paths containing
                   # "Windows Security Studio" without preserving the quotes.
                   [string]$SbomSourcePath = [System.IO.Path]::Combine($env:RUNNER_TEMP, 'wss-source')
+                  [string]$SbomManifestPath = [System.IO.Path]::Combine($env:RUNNER_TEMP, 'wss-manifest')
                   if (Test-Path -LiteralPath $SbomSourcePath) {
                       Remove-Item -LiteralPath $SbomSourcePath -Force
+                  }
+                  if (Test-Path -LiteralPath $SbomManifestPath) {
+                      Remove-Item -LiteralPath $SbomManifestPath -Recurse -Force
                   }
                   $null = New-Item -ItemType Junction -Path $SbomSourcePath -Target $script:WSSDirectory
 
                   # https://github.com/microsoft/sbom-tool/blob/main/docs/sbom-tool-arguments.md
-                  . "${Env:RUNNER_TEMP}\sbom-tool.exe" generate -b $MSIXBundleOutput -bc $SbomSourcePath -pn 'Windows Security Studio' -ps 'OFFSECHQ' -pv $MSIXVersion -nsb 'https://github.com/OFFSECHQ/windows-security-studio' -V Verbose -gt true -li true -pm true -D true -lto 80
+                  . "${Env:RUNNER_TEMP}\sbom-tool.exe" generate -b $MSIXBundleOutput -bc $SbomSourcePath -m $SbomManifestPath -pn 'Windows Security Studio' -ps 'OFFSECHQ' -pv $MSIXVersion -nsb 'https://github.com/OFFSECHQ/windows-security-studio' -V Verbose -gt true -li true -pm true -D true -lto 80
 
                   # Saving the details of the SBOM file
-                  Add-Content -Path ($env:GITHUB_ENV, $env:GITHUB_OUTPUT) -Value "SBOM_PATH=$MSIXBundleOutput/_manifest/spdx_2.2/manifest.spdx.json"
+                  [string]$SbomOutputPath = [System.IO.Path]::Combine($SbomManifestPath, 'spdx_2.2', 'manifest.spdx.json')
+                  if (-not [System.IO.File]::Exists($SbomOutputPath)) {
+                      throw [System.IO.FileNotFoundException]::New("Generated SBOM was not found at $SbomOutputPath")
+                  }
+                  Add-Content -Path ($env:GITHUB_ENV, $env:GITHUB_OUTPUT) -Value "SBOM_PATH=$SbomOutputPath"
                   Add-Content -Path ($env:GITHUB_ENV, $env:GITHUB_OUTPUT) -Value 'SBOM_NAME=manifest.spdx.json'
               }
 
@@ -709,7 +717,7 @@ jobs:
               @{ Path = "${{ env.MSIXBundle_PATH }}"; Name = $StandaloneBundleName }
               @{ Path = "${{ env.CERT_PATH }}"; Name = 'OFFSECHQ_CodeSigning.cer' }
               @{ Path = "${{ env.X64MSBuildLog_PATH }}"; Name = 'X64MSBuildLog.binlog' }
-              @{ Path = "${{ env.X64Symbol_PATH }}"; Name = "${{ env.X64Symbol_NAME }}" }
+              @{ Path = "${{ env.X64Symbol_PATH }}"; Name = "${{ env.X64Symbol_NAME }}".Replace('Windows Security Studio', 'Windows.Security.Studio') }
               @{ Path = "${{ env.SBOM_PATH }}"; Name = "${{ env.SBOM_NAME }}" }
           )
           [string]$DraftReleaseId = $env:DRAFT_RELEASE_ID

--- a/WSS_MIGRATION.md
+++ b/WSS_MIGRATION.md
@@ -264,6 +264,12 @@ The Windows release build and smoke test must cover:
   published once instead of restored/cleaned/built/published, and the main app
   now restores and publishes/packages in one pass. Draft-release uploads now
   replace same-named assets so reruns are idempotent.
+- The first optimized run completed the build/package work and began replacing
+  release assets in 11m16s, then exposed GitHub's normalization of spaces to
+  dots in the symbol asset name. Normalized that name before matching/uploading.
+  Moved the generated SBOM manifest outside the component scan root so the tool
+  cannot discover its own output while source/package detection is still
+  running.
 
 ## Completion Definition
 


### PR DESCRIPTION
## Summary
- normalize the WSS symbol release-asset name before replacement and upload
- place the generated SBOM outside its component scan root
- validate the generated SBOM path before exposing it to later steps
- record the first optimized run result

## Evidence
Run 30145367198 completed the optimized compile/package/sign/SBOM path in 11m16s. Four existing assets were replaced successfully before the unnormalized symbol name collided.

## Validation
- actionlint 1.7.12
- all three embedded PowerShell steps parse after expression substitution
- `git diff --check`