### PR TITLE
Create WSS SBOM output directory

### DIFF
--- a/.github/workflows/Build Windows Security Studio MSIX Package.yml
+++ b/.github/workflows/Build Windows Security Studio MSIX Package.yml
@@ -615,9 +615,13 @@ jobs:
                       Remove-Item -LiteralPath $SbomManifestPath -Recurse -Force
                   }
                   $null = New-Item -ItemType Junction -Path $SbomSourcePath -Target $script:WSSDirectory
+                  $null = New-Item -ItemType Directory -Path $SbomManifestPath
 
                   # https://github.com/microsoft/sbom-tool/blob/main/docs/sbom-tool-arguments.md
                   . "${Env:RUNNER_TEMP}\sbom-tool.exe" generate -b $MSIXBundleOutput -bc $SbomSourcePath -m $SbomManifestPath -pn 'Windows Security Studio' -ps 'OFFSECHQ' -pv $MSIXVersion -nsb 'https://github.com/OFFSECHQ/windows-security-studio' -V Verbose -gt true -li true -pm true -D true -lto 80
+                  if ($LASTEXITCODE -ne 0) {
+                      throw [System.InvalidOperationException]::New("SBOM generation failed. Exit Code: $LASTEXITCODE")
+                  }
 
                   # Saving the details of the SBOM file
                   [string]$SbomOutputPath = [System.IO.Path]::Combine($SbomManifestPath, 'spdx_2.2', 'manifest.spdx.json')

--- a/WSS_MIGRATION.md
+++ b/WSS_MIGRATION.md
@@ -270,6 +270,10 @@ The Windows release build and smoke test must cover:
   Moved the generated SBOM manifest outside the component scan root so the tool
   cannot discover its own output while source/package detection is still
   running.
+- The next validation confirmed the optimized compile, Native AOT package, and
+  signing path again, then showed that the SBOM tool requires a custom manifest
+  directory to exist before invocation. Created it explicitly and added a
+  direct exit-code check before validating the generated manifest.
 
 ## Completion Definition
 


### PR DESCRIPTION
## Summary
- create the custom SBOM manifest directory before invoking the Microsoft tool
- fail immediately on a nonzero SBOM generator exit code
- retain explicit verification of the generated manifest path

## Evidence
Run 30145764280 reached signed bundle creation, then the SBOM tool reported exactly: `ManifestDirPath directory not found`.