### PR TITLE
Use generated WSS SBOM manifest path

### DIFF
--- a/.github/workflows/Build Windows Security Studio MSIX Package.yml
+++ b/.github/workflows/Build Windows Security Studio MSIX Package.yml
@@ -624,7 +624,7 @@ jobs:
                   }
 
                   # Saving the details of the SBOM file
-                  [string]$SbomOutputPath = [System.IO.Path]::Combine($SbomManifestPath, 'spdx_2.2', 'manifest.spdx.json')
+                  [string]$SbomOutputPath = [System.IO.Path]::Combine($SbomManifestPath, '_manifest', 'spdx_2.2', 'manifest.spdx.json')
                   if (-not [System.IO.File]::Exists($SbomOutputPath)) {
                       throw [System.IO.FileNotFoundException]::New("Generated SBOM was not found at $SbomOutputPath")
                   }

--- a/WSS_MIGRATION.md
+++ b/WSS_MIGRATION.md
@@ -274,6 +274,10 @@ The Windows release build and smoke test must cover:
   signing path again, then showed that the SBOM tool requires a custom manifest
   directory to exist before invocation. Created it explicitly and added a
   direct exit-code check before validating the generated manifest.
+- The following runner telemetry confirmed successful SBOM generation with 60
+  packages and 357 relationships. Corrected the validation/output path to
+  include the `_manifest` directory that the tool creates beneath a custom
+  manifest root.
 
 ## Completion Definition
 


### PR DESCRIPTION
## Summary
- use the exact custom-manifest path emitted by Microsoft SBOM Tool
- record the verified SBOM package and relationship counts

## Evidence
Run 30146163124 reported `Result=Success`, 60 packages, 357 relationships, and emitted `wss-manifest\_manifest\spdx_2.2\manifest.spdx.json`.