### PR TITLE
Write a valid WSS SBOM timestamp

### DIFF
--- a/.github/workflows/Build Windows Security Studio MSIX Package.yml
+++ b/.github/workflows/Build Windows Security Studio MSIX Package.yml
@@ -616,9 +616,12 @@ jobs:
                   }
                   $null = New-Item -ItemType Junction -Path $SbomSourcePath -Target $script:WSSDirectory
                   $null = New-Item -ItemType Directory -Path $SbomManifestPath
+                  [string]$SbomGenerationTimestamp = [System.DateTime]::UtcNow.ToString(
+                      'yyyy-MM-ddTHH:mm:ssZ',
+                      [System.Globalization.CultureInfo]::InvariantCulture)
 
                   # https://github.com/microsoft/sbom-tool/blob/main/docs/sbom-tool-arguments.md
-                  . "${Env:RUNNER_TEMP}\sbom-tool.exe" generate -b $MSIXBundleOutput -bc $SbomSourcePath -m $SbomManifestPath -pn 'Windows Security Studio' -ps 'OFFSECHQ' -pv $MSIXVersion -nsb 'https://github.com/OFFSECHQ/windows-security-studio' -V Verbose -gt true -li true -pm true -D true -lto 80
+                  . "${Env:RUNNER_TEMP}\sbom-tool.exe" generate -b $MSIXBundleOutput -bc $SbomSourcePath -m $SbomManifestPath -pn 'Windows Security Studio' -ps 'OFFSECHQ' -pv $MSIXVersion -nsb 'https://github.com/OFFSECHQ/windows-security-studio' -V Verbose -gt $SbomGenerationTimestamp -li true -pm true -D true -lto 80
                   if ($LASTEXITCODE -ne 0) {
                       throw [System.InvalidOperationException]::New("SBOM generation failed. Exit Code: $LASTEXITCODE")
                   }

--- a/WSS_MIGRATION.md
+++ b/WSS_MIGRATION.md
@@ -278,6 +278,11 @@ The Windows release build and smoke test must cover:
   packages and 357 relationships. Corrected the validation/output path to
   include the `_manifest` directory that the tool creates beneath a custom
   manifest root.
+- The first fully green optimized run completed its build job in 10m53s,
+  replacing all six draft-release assets and completing the metadata job.
+  Artifact inspection then caught an invalid literal `"true"` SBOM creation
+  timestamp inherited from the old workflow; replaced it with an invariant UTC
+  ISO 8601 timestamp.
 
 ## Completion Definition
 


### PR DESCRIPTION
## Summary
- pass an invariant ISO 8601 UTC timestamp to Microsoft SBOM Tool
- record the first fully green optimized release result

## Evidence
The downloaded release SBOM contained `creationInfo.created: "true"`; the SBOM CLI documents `-gt` as a timestamp argument, not a Boolean.